### PR TITLE
Convert package long description to reST

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,14 @@ except ImportError:
     from distutils.core import setup
 
 
-with open('README.md') as fh:
-    long_description = fh.read()
+readme_file = 'README.md'
+try:
+    import pypandoc
+    long_description = pypandoc.convert(readme_file, 'rst')
+except (ImportError, OSError) as e:
+    print('No pypandoc or pandoc: %s' % (e,))
+    with open(readme_file) as fh:
+        long_description = fh.read()
 
 with open('./nanoservice/version.py') as fh:
     for line in fh:


### PR DESCRIPTION
Hey, interesting library!
This patch needs pypandoc and pandoc available when uploading package to PyPI to work, it should make package description nicely formatted.
